### PR TITLE
Fix Ikonli icons not visible after installation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gjpgabayeron</groupId>
     <artifactId>PseudoPad</artifactId>
-    <version>0.0-DEV</version>
+    <version>0.0.1-DEV1</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -76,6 +76,8 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>pseudopad.Main</mainClass>
                                 </transformer>
+                                <!-- Required for Ikonli icons - merges META-INF/services files -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                         </configuration>
                     </execution>

--- a/setup.iss
+++ b/setup.iss
@@ -2,9 +2,10 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "PseudoPad"
-#define MyAppVersion "1.0"
-#define MyAppPublisher "gjpgabayeron"
+#define MyAppVersion "v0.0.1-dev1"
+#define MyAppPublisher "PseudoPad Team"
 #define MyAppExeName "PseudoPad.exe"
+#define MyAppURL "https://github.com/justCallMeJeg/PseudoPad"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -14,6 +15,9 @@ AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}
 AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
 ; Remove the following line to run in administrative install mode (install for all users.)


### PR DESCRIPTION
## Summary
Fixes critical bug where Ikonli icons were not rendering in the packaged application.

## Changes
- ✅ Added `ServicesResourceTransformer` to Maven Shade plugin (fixes icon loading)
- ✅ Version bump to `0.0.1-DEV1`
- ✅ Updated installer version

## Root Cause
Maven Shade plugin was overwriting `META-INF/services` files instead of merging them, breaking Ikonli's ServiceLoader discovery.

## Testing
- [x] Build successful
- [x] Icons visible in PseudoPad.exe
- [x] Installer tested

Fixes #5